### PR TITLE
Improve performance of EphemerisNBP propagation by at least 10x using Common Subexpression Elimination (CSE)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Dan Padilha"]
 version = "0.1.0"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqSensitivity = "41bf760c-e81c-5289-8e54-58b1f1f8abe2"
@@ -33,9 +34,12 @@ SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+DataStructures = "0.18.9"
 DiffEqBase = "6.53.5"
 DiffEqSensitivity = "6.42.0"
 DifferentialEquations = "6.16.0"
@@ -61,5 +65,7 @@ SciMLBase = "1.8"
 SimpleTraits = "0.9.3"
 StaticArrays = "0.12.5, 1.0"
 StatsPlots = "0.14.17"
+SymbolicUtils = "0.8.4"
+Symbolics = "0.1.2"
 Unitful = "1.5.0"
 julia = "1.5.3"

--- a/src/dynamics/dynamical_models.jl
+++ b/src/dynamics/dynamical_models.jl
@@ -2,9 +2,12 @@
 # GENERIC MODEL METHODS #
 #-----------------------#
 
+import ..cse
+
+# wrap_code: perform common substring elimination to improve performance of the resulting models.
 @doc """Generic constructor for a DynamicalModel's underlying ODEFunctions."""
-function (T::Type{<:Abstract_ModelODEFunctions})(args...; kwargs...)
-    _ode, deduplicate_terms = ODESystem(T, args...; kwargs...)
+function (T::Type{<:Abstract_ModelODEFunctions})(args...; wrap_code=(cse, cse), kwargs...)
+    _ode = ODESystem(T, args...; kwargs...)
 
     # Reduce high-order system to 1st-order (re-ordering to keep the original equations first)
     # NOTE: need to expand the RHS derivatives before calling order-lowering
@@ -17,8 +20,8 @@ function (T::Type{<:Abstract_ModelODEFunctions})(args...; kwargs...)
 
     # Generate the functions
     # TODO: Add support for tgrad (need to define derivative(get_pos) for EphemerisNBP)
-    ode_f = ODEFunction(ode; jac=true, tgrad=false, eval_expression=false, eval_module=@__MODULE__, deduplicate_terms)
-    ode_stm_f = STM_ODEFunction(ode, ode_f; deduplicate_terms)
+    ode_f = ODEFunction(ode; jac=true, tgrad=false, eval_expression=false, eval_module=@__MODULE__, wrap_code)
+    ode_stm_f = STM_ODEFunction(ode, ode_f; wrap_code)
     T(ode, ode_f, ode_stm_f)
 end
 
@@ -34,7 +37,7 @@ has_jacobian(X::Type{<:DiffEqBase.ODEFunction}) = !isnothing(fieldtype(X, :jac))
     Matrix simultaneously with the given function f. This requires f to have
     a computable Jacobian function.
 """
-@traitfn function STM_ODEFunction(ode::ModelingToolkit.AbstractODESystem, f::::HasJacobian; deduplicate_terms=[])
+@traitfn function STM_ODEFunction(ode::ModelingToolkit.AbstractODESystem, f::::HasJacobian; kwargs...)
     # TODO: Output just the variational equations, join as a SplitODEProblem
     # TODO: Memoize this function! It's very slightly slow for EphemerisNBP
 
@@ -62,7 +65,7 @@ has_jacobian(X::Type{<:DiffEqBase.ODEFunction}) = !isnothing(fieldtype(X, :jac))
         iv,
         [dvs..., ϕ...],  # Append the STM and motion state variables
         params)
-    stm_f = ODEFunction(stm_ode; sparse=true, eval_expression=false, eval_module=@__MODULE__, deduplicate_terms)
+    stm_f = ODEFunction(stm_ode; sparse=true, eval_expression=false, eval_module=@__MODULE__, kwargs...)
 end
 
 #---------#

--- a/src/dynamics/dynamical_models.jl
+++ b/src/dynamics/dynamical_models.jl
@@ -77,6 +77,11 @@ ModelingToolkit.varmap_to_vars(model::Abstract_DynamicalModel, varmap) = Modelin
 DiffEqBase.isinplace(f::Abstract_DynamicalModel, _) = true
 
 # XXX: Need these due to new ModelingToolkit interface.
+function Base.getproperty(sys::Abstract_ModelODEFunctions, name::Symbol)
+    # XXX: This is very much needed to avoid the depwarn introduced in
+    # ModelingToolkit, especially in Pkg.test() environments!
+    return getfield(sys, name)
+end
 ModelingToolkit.get_systems(::Abstract_ModelODEFunctions) = []
 ModelingToolkit.get_eqs(f::Abstract_ModelODEFunctions) = ModelingToolkit.get_eqs(f.ode_system)
 ModelingToolkit.get_states(f::Abstract_ModelODEFunctions) = ModelingToolkit.get_states(f.ode_system)

--- a/src/dynamics/models/bc4bp.jl
+++ b/src/dynamics/models/bc4bp.jl
@@ -39,7 +39,7 @@ function ModelingToolkit.ODESystem(::Type{_BC4BP_ODEFunctions})
     eqs    = @. D2(p) ~ [+2D(y) + x, -2D(x) + y, 0] + forces
 
     # Simplify and return the system
-    return ODESystem(simplify.(eqs), t, [x, y, z], [μ, μ2, a3, α0, a3, ω3]), []
+    return ODESystem(simplify.(eqs), t, [x, y, z], [μ, μ2, a3, α0, a3, ω3])
 end
 
 # Build the equations at pre-compile time

--- a/src/dynamics/models/cr3bp.jl
+++ b/src/dynamics/models/cr3bp.jl
@@ -12,10 +12,10 @@ end
 
 function ModelingToolkit.ODESystem(::Type{_CR3BP_ODEFunctions})
     # Build from the ER3BP equations (with eccentricity = 0 for circular)
-    eqs_er3bp, deduplicate_terms = ODESystem(_ER3BP_ODEFunctions)
+    eqs_er3bp = ODESystem(_ER3BP_ODEFunctions)
     (μ, e) = parameters(eqs_er3bp)
     eqs = [eq.lhs ~ simplify(substitute(eq.rhs, e => 0)) for eq in equations(eqs_er3bp)]
-    return ODESystem(eqs, independent_variable(eqs_er3bp), states(eqs_er3bp), [μ]), deduplicate_terms
+    return ODESystem(eqs, independent_variable(eqs_er3bp), states(eqs_er3bp), [μ])
 end
 
 # Build the equations at pre-compile time

--- a/src/dynamics/models/er3bp.jl
+++ b/src/dynamics/models/er3bp.jl
@@ -29,7 +29,7 @@ function ModelingToolkit.ODESystem(::Type{_ER3BP_ODEFunctions})
         f,
         [x, y, z],
         [μ, e]
-    ), []
+    )
 end
 
 @doc "Centrifugal potential [DeiTos2017, Eq.13; Ichinomiya 2018, Eq. 2.2]"

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -14,3 +14,80 @@ Base.unsafe_convert(T::Type{<:Any}, x::ForwardDiff.Dual) = T(ForwardDiff.value.(
 
 # Compute norms for arrays of symbolic variables (as needed by EphemerisNBP)
 LinearAlgebra.norm(a::AbstractArray{<:ModelingToolkit.Num}) = sum(a .^ 2)^(1/2)
+
+
+
+
+# --------------------------------#
+# Common Subexpression Evaluation #
+# --------------------------------#
+using SymbolicUtils.Code: Let, Func, MakeArray, SetArray, (←), LiteralExpr
+using Symbolics: Equation
+
+# Code below copied from Shashi Gowda's work in https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/200
+# Under the MIT License as per conditions below:
+
+# Copyright (c) 2020: Shashi Gowda, Yingbo Ma, Mason Protter, Julia Computing.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+### Code-related utilities
+
+using SymbolicUtils
+
+using SymbolicUtils: Sym, Term, istree
+
+using SymbolicUtils.Rewriters
+
+using DataStructures
+
+### Common subexprssion evaluation
+
+newsym() = Sym{Number}(gensym("cse"))
+
+function _cse(expr, dict=OrderedDict())
+    r = @rule ~x::istree => haskey(dict, ~x) ? dict[~x] : dict[~x] = newsym()
+    final = Postwalk(Chain([r]))(expr)
+end
+
+function cse(expr)
+    !istree(expr) && return expr
+    dict=OrderedDict()
+    final = _cse(expr, dict)
+    Let([var ← ex for (ex, var) in pairs(dict)], final)
+end
+
+function _cse(exprs::AbstractArray)
+    dict = OrderedDict()
+    final = map(ex->_cse(ex, dict), exprs)
+    ([var ← ex for (ex, var) in pairs(dict)], final)
+end
+
+function cse(x::MakeArray)
+    assigns, expr = _cse(x.elems)
+    Let(assigns, MakeArray(expr, x.similarto, x.output_eltype))
+end
+
+function cse(x::SetArray)
+    assigns, expr = _cse(x.elems)
+    Let(assigns, SetArray(x.inbounds, x.arr, expr))
+end
+# --------------------------------#
+# End of copyrighted code         #
+# --------------------------------#

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -91,3 +91,26 @@ end
 # --------------------------------#
 # End of copyrighted code         #
 # --------------------------------#
+
+function _cse(eq::Num, dict)
+    final = _cse(Symbolics.value(eq), dict)
+    Num(final)
+end
+
+function _cse(eq::Equation, dict)
+    lhs = _cse(eq.lhs, dict)
+    rhs = _cse(eq.rhs, dict)
+    Equation(lhs, rhs)
+end
+
+function cse(x::LiteralExpr)
+    # XXX: Assumes that the LiteralExpr contains a LineNumber as the first argument
+    LiteralExpr(quote
+        $(cse.(x.ex.args[2:end])...)
+    end)
+end
+
+function cse(x::Func)
+    body = cse(x.body)
+    return Func(x.args, x.kwargs, body)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/nbp.jl
+++ b/test/nbp.jl
@@ -44,7 +44,7 @@ end
     model = EphemerisNBP
     sys = model(bodies...)
 
-    tspan = isa(sys, EphemerisNBP) ? (0., 3600.0*24*30) : (0, 2π)
+    tspan = (0., 3600.0*24*30) 
     prob = State(sys, SynodicFrame(), u0, tspan)
 
     # Test default performance of prob (with CSE)


### PR DESCRIPTION
Here, we implement a WIP solution for CSE from JuliaSymbolics/SymbolicUtils.jl#200 and use it to automatically rewrite the propagation functions of every astrodynamical model. For the EphemerisNBP model, this improves the performance by up to 20 times on simple trajectory propagation, and potentially much more. Note: the performance of the other models remains the same as before.

From the [OrbitalTrajectories.jl paper](https://www.researchgate.net/publication/348929030_Modern_Numerical_Programming_with_Julia_for_Astrodynamic_Trajectory_Design) (final published version):

> Currently, we circumvent this by later intercepting the integration timestep code generated by ModelingToolkit.jl and using Julia’s meta-programming capabilities to inject an intermediate variable storing the value of a single call to the spkpos function, substituting it for each symbolic use of pos. In assessing the performance of the EphemerisNBP in later sections, this results in ∼15× faster integration than the default behaviour of redundant calls to spkpos.∗
> ∗Future versions of ModelingToolkit.jl and its underlying SymbolicUtils.jl are expected to provide support for
common-subexpression elimination, automating this process and improving the default performance of symbolic models.