### PR TITLE
Improve automatic SPICE kernel downloading to avoid incomplete downloads and warn the user.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrbitalTrajectories"
 uuid = "2b613a20-8d2a-5290-b19f-e06f4bcc2e7d"
 authors = ["Dan Padilha"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/SPICE/spice.jl
+++ b/src/SPICE/spice.jl
@@ -63,39 +63,35 @@ module SpiceUtils
         kernel_dir    = artifact_path(meta_hash)
         kernel_paths  = [basename(url) for url in download_URLs]
 
-        # Check if the kernel has already been downloaded before, and if not, download it.
-        temp_dir = mktempdir(first(Artifacts.artifacts_dirs()))
-        for (kernel, url) in zip(kernel_paths, download_URLs)
-            if !artifact_exists(meta_hash)
-                # Make a temporary path to store the unfinished download
-                download_path = joinpath(temp_dir, kernel)
+        # Check if the kernel has already been downloaded before, and if not, download it to a temporary directory.
+        temp_dir = artifact_exists(meta_hash) ? nothing : mktempdir(first(Artifacts.artifacts_dirs()))
+        if !isnothing(temp_dir)
+            # Create a progress bar.
+            progress = (name) -> begin
+                max_n = 10000
+                bar = Progress(max_n; desc="Downloading NAIF kernel: $(name)", color=Base.info_color())
+                (total, now) -> update!(bar, total > 0 ? round(Int, (now / total) * max_n) : 0)
+            end
 
-                progress = begin
-                    max_n = 10000
-                    bar = Progress(max_n; desc="Downloading NAIF kernel: $(basename(url))", color=Base.info_color())
-                    (total, now) -> update!(bar, total > 0 ? round(Int, (now / total) * max_n) : 0)
-                end
-
-                # Download the kernel into the temporary folder.
+            for (kernel, url) in zip(kernel_paths, download_URLs)
                 try
-                    Downloads.download(url, download_path; progress)
+                    Downloads.download(url, joinpath(temp_dir, kernel); progress=progress(kernel))
                 finally
                     finish!(bar)
                 end
             end
-        end
 
-        # All kernels are now downloaded; move them into the final kernel folder.
-        mv(temp_dir, kernel_dir)
+            # All kernels are now downloaded; move them into the final kernel folder.
+            mv(temp_dir, kernel_dir)
+        end
 
         # Load each kernel into SPICE.
         for (kernel, url) in zip(kernel_paths, download_URLs)
             kernel_path = joinpath(kernel_dir, kernel)
             if !isfile(kernel_path)
                 error("Could not find kernel file '$(kernel)'. Delete the $(kernel_dir) directory and try again.")
-            else
-                furnsh(kernel_path)
             end
+            furnsh(kernel_path)
         end
 
         return true

--- a/src/SPICE/spice.jl
+++ b/src/SPICE/spice.jl
@@ -61,7 +61,7 @@ module SpiceUtils
         meta_hash     = Base.SHA1(meta["git-tree-sha1"])
         download_URLs = [d["url"] for d in meta["download"]]
         kernel_dir    = artifact_path(meta_hash)
-        kernel_paths  = [basename(url) for url in download_URLs]
+        kernel_names  = [basename(url) for url in download_URLs]
 
         # Check if the kernel has already been downloaded before, and if not, download it to a temporary directory.
         temp_dir = artifact_exists(meta_hash) ? nothing : mktempdir(first(Artifacts.artifacts_dirs()))
@@ -73,7 +73,7 @@ module SpiceUtils
                 (total, now) -> update!(bar, total > 0 ? round(Int, (now / total) * max_n) : 0)
             end
 
-            for (kernel, url) in zip(kernel_paths, download_URLs)
+            for (kernel, url) in zip(kernel_names, download_URLs)
                 try
                     Downloads.download(url, joinpath(temp_dir, kernel); progress=progress(kernel))
                 finally
@@ -86,7 +86,7 @@ module SpiceUtils
         end
 
         # Load each kernel into SPICE.
-        for (kernel, url) in zip(kernel_paths, download_URLs)
+        for (kernel, url) in zip(kernel_names, download_URLs)
             kernel_path = joinpath(kernel_dir, kernel)
             if !isfile(kernel_path)
                 error("Could not find kernel file '$(kernel)'. Delete the $(kernel_dir) directory and try again.")

--- a/src/SPICE/spice.jl
+++ b/src/SPICE/spice.jl
@@ -66,16 +66,12 @@ module SpiceUtils
         # Check if the kernel has already been downloaded before, and if not, download it to a temporary directory.
         temp_dir = artifact_exists(meta_hash) ? nothing : mktempdir(first(Artifacts.artifacts_dirs()))
         if !isnothing(temp_dir)
-            # Create a progress bar.
-            progress = (name) -> begin
-                max_n = 10000
-                bar = Progress(max_n; desc="Downloading NAIF kernel: $(name)", color=Base.info_color())
-                (total, now) -> update!(bar, total > 0 ? round(Int, (now / total) * max_n) : 0)
-            end
-
+            max_n = 10000
             for (kernel, url) in zip(kernel_names, download_URLs)
+                bar = Progress(max_n; desc="Downloading NAIF kernel: $(kernel)", color=Base.info_color())
+                progress = (total, now) -> update!(bar, total > 0 ? round(Int, (now / total) * max_n) : 0)
                 try
-                    Downloads.download(url, joinpath(temp_dir, kernel); progress=progress(kernel))
+                    Downloads.download(url, joinpath(temp_dir, kernel); progress)
                 finally
                     finish!(bar)
                 end

--- a/src/SPICE/spice.jl
+++ b/src/SPICE/spice.jl
@@ -64,11 +64,10 @@ module SpiceUtils
         kernel_paths  = [basename(url) for url in download_URLs]
 
         # Check if the kernel has already been downloaded before, and if not, download it.
+        temp_dir = mktempdir(first(Artifacts.artifacts_dirs()))
         for (kernel, url) in zip(kernel_paths, download_URLs)
             if !artifact_exists(meta_hash)
-
                 # Make a temporary path to store the unfinished download
-                temp_dir = mktempdir(first(Artifacts.artifacts_dirs()))
                 download_path = joinpath(temp_dir, kernel)
 
                 progress = begin


### PR DESCRIPTION
The automatic SPICE kernel downloader will now download kernels to a temporary directory first, before finally moving them to the appropriate Julia artifacts folder. This avoids any potential problems in case the kernel download doesn't complete, but the artifacts folder already exists. We also now throw an error if such a problem occurs, warning the user to delete the relevant artifact folder and try again.