### PR TITLE
[SciMLBase piracy] Add support for control variables being passed into uncertain initial conditions in QuadratureProblems used by DiffEqUncertainty.

### DIFF
--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -2,6 +2,7 @@ using ModelingToolkit
 using Unitful
 using LinearAlgebra
 using ForwardDiff
+using SciMLBase
 
 # TODO: Check which of these are still in use and/or necessary.
 
@@ -15,7 +16,8 @@ Base.unsafe_convert(T::Type{<:Any}, x::ForwardDiff.Dual) = T(ForwardDiff.value.(
 # Compute norms for arrays of symbolic variables (as needed by EphemerisNBP)
 LinearAlgebra.norm(a::AbstractArray{<:ModelingToolkit.Num}) = sum(a .^ 2)^(1/2)
 
-
+# Add support for control variables being passed into uncertain initial conditions in DiffEqUncertainty
+SciMLBase.QuadratureProblem(f,lb,ub,args...;kwargs...) = QuadratureProblem{isinplace(f, 3)}(f,ForwardDiff.value.(lb),ForwardDiff.value.(ub),args...;kwargs...)
 
 
 # --------------------------------#


### PR DESCRIPTION
This overrides the constructor for QuadratureProblems to ignore the auto-differentiated bounds of the provided distribution, which would otherwise result in errors further downstream. This assumes that the bounds do not have control variables in them, otherwise this is not valid.