### PR TITLE
Add trajectory interpolation support for arbitrary arrays of time points (i.e. `traj(list_of_times)`).

### DIFF
--- a/src/dynamics/models/3bp.jl
+++ b/src/dynamics/models/3bp.jl
@@ -160,10 +160,10 @@ function check_distance(u, t, system::Abstract_R3BPModel, body::Symbol, distance
     return norm(@view(u[1:3]) - body_pos) - distance
 end
 
-function convert_to_frame(state::State{<:Abstract_R3BPModel,<:Abstract_ReferenceFrame}, frame::InertialFrame)
+function convert_to_frame(state::State{<:Abstract_R3BPModel,<:SynodicFrame}, frame::InertialFrame)
     to_inertial = state_to_inertial(state.tspan[1])
     converted_u0 = to_inertial * state.u0
-    new_state = State(state.model, InertialFrame(), converted_u0, state.tspan)
+    new_state = State(state.model, frame, converted_u0, state.tspan)
     return new_state
 end
 

--- a/src/dynamics/orbital_trajectories.jl
+++ b/src/dynamics/orbital_trajectories.jl
@@ -39,6 +39,10 @@ ModelingToolkit.parameters(state::State) = ModelingToolkit.parameters(state.mode
 
 # Interpolation
 (traj::Trajectory)(t::Number) = State(traj.model, traj.frame, traj.sol(t), (t, t))
+function (traj::Trajectory)(t::AbstractArray{<:Number})
+    new_sol = DiffEqBase.build_solution(traj.prob, traj.alg, t, traj.sol(t); retcode=traj.retcode)
+    return Trajectory(traj.model, traj.frame, new_sol)
+end
 
 # Indexing
 Base.getindex(state::State, idx...) = getindex(state.prob.u0, idx...)

--- a/src/dynamics/orbital_trajectories.jl
+++ b/src/dynamics/orbital_trajectories.jl
@@ -40,7 +40,7 @@ ModelingToolkit.parameters(state::State) = ModelingToolkit.parameters(state.mode
 # Interpolation
 (traj::Trajectory)(t::Number) = State(traj.model, traj.frame, traj.sol(t), (t, t))
 function (traj::Trajectory)(t::AbstractArray{<:Number})
-    new_sol = DiffEqBase.build_solution(traj.prob, traj.alg, t, traj.sol(t); retcode=traj.retcode)
+    new_sol = DiffEqBase.build_solution(traj.prob, traj.alg, t, traj.sol(t); interp=traj.interp, retcode=traj.retcode)
     return Trajectory(traj.model, traj.frame, new_sol)
 end
 

--- a/src/dynamics/plotting.jl
+++ b/src/dynamics/plotting.jl
@@ -107,6 +107,8 @@ end
 end
 
 @recipe function f(sol::Union{DiffEqBase.ODESolution{T}, OrdinaryDiffEq.ODECompositeSolution{T}}) where {T <: ForwardDiff.Dual}
+    # TODO: Fix the type dispatch on this, since it's doing piracy.
+
     trace_vars = get(plotattributes, :trace, false)
     trace_stability = get(plotattributes, :trace_stability, false)
     denseplot = get(plotattributes, :denseplot, true)

--- a/src/dynamics/reference_frames.jl
+++ b/src/dynamics/reference_frames.jl
@@ -55,4 +55,5 @@ function collision(system::Abstract_DynamicalModel, body, dist=bodvrd(String(bod
     end
 end
 check_distance(u, t, system::Abstract_DynamicalModel, body) = error("check_distance not defined for $(nameof(typeof(system)))")
-crashed(sol::Trajectory) = sol.sol.retcode == CRASHED_RETCODE
+crashed(sol::Trajectory) = crashed(sol.sol)
+crashed(sol::ODESolution) = sol.retcode == CRASHED_RETCODE

--- a/src/dynamics/reference_frames.jl
+++ b/src/dynamics/reference_frames.jl
@@ -56,4 +56,3 @@ function collision(system::Abstract_DynamicalModel, body, dist=bodvrd(String(bod
 end
 check_distance(u, t, system::Abstract_DynamicalModel, body) = error("check_distance not defined for $(nameof(typeof(system)))")
 crashed(sol::Trajectory) = sol.sol.retcode == CRASHED_RETCODE
-crashed(sol::ODESolution) = sol.retcode == CRASHED_RETCODE


### PR DESCRIPTION
Previously, you could only natively interpolate a `Trajectory` at a single time point, resulting in a `State` at that time. Here, we additionaly expose the underlying `ODESolution`'s interpolation capabilities to return a `Trajectory` of all the interpolated points.