### PR TITLE
Subtype State as an AbstractODEProblem (instead of DEProblem)

### DIFF
--- a/src/dynamics/dynamical_models.jl
+++ b/src/dynamics/dynamical_models.jl
@@ -74,7 +74,8 @@ end
 Base.show(io::IO, x::Abstract_DynamicalModel) = show(io, typeof(x))
 Base.show(io::IO, x::Type{<:Abstract_DynamicalModel}) = print(io, nameof(x))
 ModelingToolkit.varmap_to_vars(model::Abstract_DynamicalModel, varmap) = ModelingToolkit.varmap_to_vars(varmap, parameters(model))
-DiffEqBase.isinplace(f::Abstract_DynamicalModel, _) = true
+DiffEqBase.isinplace(f::Abstract_DynamicalModel) = true
+DiffEqBase.isinplace(f::Abstract_DynamicalModel, _) = isinplace(f)
 
 # XXX: Need these due to new ModelingToolkit interface.
 function Base.getproperty(sys::Abstract_ModelODEFunctions, name::Symbol)

--- a/src/dynamics/orbital_trajectories.jl
+++ b/src/dynamics/orbital_trajectories.jl
@@ -6,13 +6,10 @@ export collision, check_distance, crashed
 # ORBITAL PROBLEMS #
 #------------------#
 
-struct State{M<:Abstract_DynamicalModel,F<:Abstract_ReferenceFrame,O<:DiffEqBase.DEProblem,uType,tType,isinplace} <: SciMLBase.AbstractODEProblem{uType,tType,isinplace}
+struct State{M<:Abstract_DynamicalModel,F<:Abstract_ReferenceFrame,uType,tType,isinplace,O<:SciMLBase.AbstractODEProblem{uType,tType,isinplace}} <: SciMLBase.AbstractODEProblem{uType,tType,isinplace}
     model :: M
     frame :: F  # Reference frame that the problem's u0 is defined in
     prob :: O
-    function State(model::M, reference_frame::F, prob::DiffEqBase.DEProblem) where {M<:Abstract_DynamicalModel, F<:Abstract_ReferenceFrame}
-        new{M,F,typeof(prob),eltype(prob.u0),eltype(prob.tspan),isinplace(model)}(model, reference_frame, prob)
-    end
 end
 State(model::Abstract_DynamicalModel, reference_frame::Abstract_ReferenceFrame, u0::AbstractArray, tspan) =
     State(model, reference_frame, MArray{Tuple{size(u0)...}}(u0), tspan)
@@ -107,7 +104,7 @@ DiffEqBase.solve(state::State, args...; reltol=1e-10, abstol=1e-10, kwargs...) =
 DiffEqBase.__solve(state::State; kwargs...) = DiffEqBase.__solve(state, DEFAULT_ALG; kwargs...)
 
 # The __solve() method does the actual heavy lifting, including converting to a Trajectory.
-function DiffEqBase.__solve(state::State, alg::Union{OrdinaryDiffEqAlgorithm,DiffEqBase.DEAlgorithm}; userdata=Dict(), callback=nothing, kwargs...)
+function DiffEqBase.__solve(state::State, alg::OrdinaryDiffEqAlgorithm; userdata=Dict(), callback=nothing, kwargs...)
     default_frame = default_reference_frame(state.model)
     real_state = convert_to_frame(state, default_frame)
 


### PR DESCRIPTION
This pull request makes States act like ODE problems by default (although the underlying actual problem can be any differential equation problem as before). Since currently no functions are (or should be) using other problem types, and some other libraries only define functions for ODE problems, it makes sense to restrict this definition for now. However, this is a (slightly) breaking change.